### PR TITLE
Set CMake minimum version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 ### CMAKE
 project( spectre-cli C )
-cmake_minimum_required( VERSION 3.0.2 )
+cmake_minimum_required( VERSION 3.5 )
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 


### PR DESCRIPTION
CMake 4 dropped support for versions below 3.5, so this needs to be bumped to support being built with CMake 4 and above.